### PR TITLE
Some fixes, privacy options and reworked the readme a bit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
+#Uncomment the following line for regular x86 systems
 FROM debian:jessie
+#Uncomment the following line for the raspberry pi
+#FROM resin/rpi-raspbian:jessie
 MAINTAINER dustyfresh, https://github.com/dustyfresh
 
 RUN apt-get update && apt-get -y install ngircd vim tor build-essential libssl-dev python-setuptools python-pip supervisor
@@ -10,4 +13,5 @@ ADD ./conf/rsyslog.conf /etc/rsyslog.conf
 ADD ./conf/ngircd.motd /etc/ngircd/ngircd.motd
 ADD ./conf/ngircd.conf /etc/ngircd/ngircd.conf
 ADD ./conf/torrc /etc/tor/torrc
+RUN chown -R irc:irc /etc/ngircd
 CMD ["/usr/bin/supervisord", "-n"]

--- a/README.md
+++ b/README.md
@@ -14,25 +14,30 @@ You can share the private key of your Tor hidden service within your circle of t
 * IRC talks on default port 6667, and yes we're using SSL. See the next section about the certificate and key specification.
 * [Tor](https://www.torproject.org/)
 * [Supervisord](http://supervisord.org/) -- this daemon will restart critical services if they are found to not be running as expected.
+* For raspberry pi: Comment out the corresponding line in the Dockerfile
 
 #### Generate SSL certs:
 
 **It important to note that the strength of your RSA keys. Since this is a hidden service you will want to use at minimum 2048 bits, but 4096 bits is better. The larger the key the more time it will take generating the key -- introduce more entropy on the host to fix this. See [Haveged](http://www.issihosts.com/haveged/).**
 
 Here is where you will generate the self signed SSL certificate. You do not need to fill anything out — just hold the enter key until the process is complete.
+
 ```
 cd ssl/ && openssl genrsa -out server.key 4096 && openssl req -new -key server.key -out server.csr && openssl x509 -req -days 1337 -in server.csr -signkey server.key -out server.crt
 ```
 
+It is wise to backup the contents of the ssl directory and make sure it doesn't fall in wrong hands. You need it when you rebuild the server (or you have to generate a new cert, but everyone that has explicitly trusted this certificate will get a warning / will be unable to connect).
+
 #### Customize the configuration:
 There are some things you will need to modify before you can get your IRC hidden service running.
+
 ```
 vim conf/ngircd.conf
 ```
 
-Change the server name, it must be a FQDN name.
+Change the server name, it must be a FQDN (Fully Qualified Domain Name, like supersecretirc.net or s0m30n10n4ddr3s.onion).
 
-Find this towards the bottom of the file and modify the operator login information:
+Find this towards the bottom of the file and modify the IRC operator login information:
 
 ```
 [Operator]
@@ -43,6 +48,8 @@ Find this towards the bottom of the file and modify the operator login informati
 Modify as you wish. This is the main admin user of the server. **Use strong passwords**!
 
 Also change the Channel at the very bottom to create your own private channel with a password.
+
+This is an example configuration, to tailor the server to your specific needs see [ngirc docs](https://github.com/ngircd/ngircd/blob/master/doc/sample-ngircd.conf.tmpl)
 
 #### Logging
 Currently this is disabled. If you wish to log you can modify the rsyslog configuration found within conf/rsyslog.conf.
@@ -60,12 +67,15 @@ docker build --rm -t onionirc .
 
 #### Run the server:
 ```
-docker run -d -v $(pwd):/var/lib/tor --name onionirc onionirc
+sudo docker run -d -v /srv/hidden-service-data:/var/lib/tor --name onionirc --restart=always -p 6667:6667 onionirc
+
 ```
+
+Where /srv/onionirc-hidden-service-data is a directory on your docker hosts filesystem. This is where the private key and the hostname of your hidden service is kept.
 
 #### Get your onion name:
 ```
-cat ./hidden_service/hostname
+cat /srv/onionirc-hidden-service-data/hostname
 ```
 
 Remember that your **private key** is in this directory. This is used to identify your host with Tor so you can use the assigned onion address. If this address changes you will need a way to notify the users of this change -- which is difficult. **Do not lose this key!** It is also recommended that you utilize an encrypted filesystem like [eCryptfs](http://ecryptfs.org/).

--- a/README.md
+++ b/README.md
@@ -65,11 +65,18 @@ vim conf/ngircd.motd
 docker build --rm -t onionirc .
 ```
 
-#### Run the server:
+#### Run the server (Tor only):
+```
+sudo docker run -d -v /srv/hidden-service-data:/var/lib/tor --name onionirc --restart=always onionirc
+
+```
+
+#### Run the server (Tor and regular connections):
 ```
 sudo docker run -d -v /srv/hidden-service-data:/var/lib/tor --name onionirc --restart=always -p 6667:6667 onionirc
 
 ```
+
 
 Where /srv/onionirc-hidden-service-data is a directory on your docker hosts filesystem. This is where the private key and the hostname of your hidden service is kept.
 

--- a/conf/ngircd.conf
+++ b/conf/ngircd.conf
@@ -1,5 +1,5 @@
 [Global]
-    Name = changme.onion
+    Name = changeme.onion
     AdminInfo1 = null
     AdminInfo2 = null
     AdminEMail = null@null.tld
@@ -29,12 +29,35 @@
     SyslogFacility = local5
     ;WebircPassword = webpwd
 
+    # Security related settings, useful for running servers with high anonimity, disable if desired
+
+    # Global password for all users needed to connect to the server
+    Password = abc
+    # Set this hostname for every client instead of the real one.
+    # Use %x to add the hashed value of the original hostname.
+    CloakHost = cloaked.host
+    # Set every clients' user name to their nickname
+    CloakUserToNick = yes
+    # Do dns lookup when a user connects
+    DNS = no
+    # Enhance user privacy slightly (useful for IRC server on TOR or I2P)
+    # by censoring some information like idle time, logon time, etc.
+    MorePrivacy = yes
+    # Silently drop all incoming CTCP requests
+    ScrubCTCP = yes
+    
+
 [Operator]
-    Name = changme
+    Name = changeme
     Password = changeme
 
 [Channel]
     Name = #PrivateLobby
-    Topic = changeme
+    Topic = Private conversation
     Modes = tnk
     Key = channelpassword
+
+[Channel]
+    Name = #general
+    Topic = General conversation
+    Modes = tn

--- a/conf/ngircd.conf
+++ b/conf/ngircd.conf
@@ -19,10 +19,6 @@
     MaxJoins = 5
 
 [Options]
-    CloakUserToNick = yes
-    DNS = no
-    Ident = no
-    MorePrivacy = yes
     PAM = no
     PredefChannelsOnly = no
     RequireAuthPing = no
@@ -31,6 +27,7 @@
 
     # Security related settings, useful for running servers with high anonimity, disable if desired
 
+    Ident = no
     # Global password for all users needed to connect to the server
     Password = abc
     # Set this hostname for every client instead of the real one.

--- a/ssl/.gitignore
+++ b/ssl/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- Docker run command didn't use any portforwardings, thus you couldn't connect, and added restart=always, makes sure the container starts after a reboot of the docker host
- chowned the ssl directory in the container because I received permission denied errors
- showed how to use this image on the rpi
- moved the hidden service directory out of the repository and used an absolute path (so the user becomes mindful about where they put this very important directory)
- Added some privacy options which I think are very useful on a irc server run over tor